### PR TITLE
Add DuckyMix Anima v1 (uncurated)

### DIFF
--- a/uncurated_models.txt
+++ b/uncurated_models.txt
@@ -366,3 +366,4 @@ untitled-pony
 pikon-reality_v2_alt
 inbetweij-no04
 cyberrealistic-flux-v2-5
+DuckyMix_Anima_v1

--- a/uncurated_models/DuckyMix_Anima_v1/metadata.json
+++ b/uncurated_models/DuckyMix_Anima_v1/metadata.json
@@ -1,0 +1,18 @@
+{
+  "name": "DuckyMix Anima v1",
+  "version": "cosmos2.5_2b",
+  "autoencoder": "qwen_image_vae_f16.ckpt",
+  "text_encoder": "qwen_3_0.6b_q8p.ckpt",
+  "clip_encoder": "duckymix_anima_v1_f16.ckpt",
+  "file": "duckymix_anima_v1_f16.ckpt",
+  "prefix": "",
+  "default_scale": 16,
+  "hires_fix_scale": 32,
+  "upcast_attention": false,
+  "high_precision_autoencoder": false,
+  "padded_text_encoding_length": 512,
+  "objective": { "u": { "condition_scale": 1 } },
+  "hugging_face_link": "Duck1ng/DuckyMix-Anima-v1",
+  "note": "An Anima merge that gives the base a soft, painterly Pony-style nudge. The aesthetic comes through by default, so it works well without quality or score tags. Inherits Anima's recommended settings: ~1MP, 30-50 steps, CFG 4-5.",
+  "copyright": "Base © 2026 CircleStone Labs; merge by Ducktopuss"
+}


### PR DESCRIPTION
Adds DuckyMix Anima v1 to the uncurated models list.

An Anima merge that gives the base a soft, painterly Pony-style nudge. The aesthetic comes through by default, so it works well without quality or score tags.

1. License: CircleStone Labs Non-Commercial License (this is a non-commercial derivative of Anima / cosmos2.5_2b). License carried over from the base model.

2. Example images: https://huggingface.co/Duck1ng/DuckyMix-Anima-v1

3. Recommended settings: ~1MP (1024px), 30-50 steps, CFG 4-5 — inherits Anima's base recommendations.

4. Age rating: 16+ 

Source (public): https://huggingface.co/Duck1ng/DuckyMix-Anima-v1